### PR TITLE
fix: use URI.parse instead of URI.new! in normalize_url function to allow unescaped characters in the path

### DIFF
--- a/lib/req_s3.ex
+++ b/lib/req_s3.ex
@@ -327,7 +327,7 @@ defmodule ReqS3 do
   end
 
   defp normalize_url(string, endpoint_url) when is_binary(string) do
-    normalize_url(URI.new!(string), endpoint_url)
+    normalize_url(URI.parse(string), endpoint_url)
   end
 
   defp normalize_url(%URI{scheme: "s3"} = url, endpoint_url) do

--- a/test/req_s3_test.exs
+++ b/test/req_s3_test.exs
@@ -149,6 +149,17 @@ defmodule ReqS3Test do
              ReqS3.presign_url(options)
   end
 
+  test "presign_url/1 encode path" do
+    options = [
+      url: "s3://wojtekmach-test/hello world.txt",
+      access_key_id: "foo",
+      secret_access_key: "bar"
+    ]
+
+    assert "https://wojtekmach-test.s3.amazonaws.com/hello%20world.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&" <>
+             _ = ReqS3.presign_url(options)
+  end
+
   test "presign_url/1 upload" do
     url = ReqS3.presign_url(url: "s3://wojtekmach-test/foo", method: :put)
     body = "hi#{Time.utc_now()}"


### PR DESCRIPTION
This PR depends on https://github.com/wojtekmach/req/pull/433.