### PR TITLE
S3 accelerator support

### DIFF
--- a/lib/req_s3.ex
+++ b/lib/req_s3.ex
@@ -95,6 +95,8 @@ defmodule ReqS3 do
     * `:endpoint_url` - if set, the endpoint URL for S3-compatible services. If
       `AWS_ENDPOINT_URL_S3` system environment variable is set, it is considered first.
 
+    * `:s3_accelerate` - if set, use the S3 Accelerate endpoint.
+
   ## Examples
 
   Note: This example assumes `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
@@ -131,17 +133,23 @@ defmodule ReqS3 do
       key = Keyword.fetch!(options, :key)
 
       endpoint_url = options[:endpoint_url] || System.get_env("AWS_ENDPOINT_URL_S3")
+      accelerate = options[:accelerate]
 
-      if endpoint_url do
-        "#{endpoint_url}/#{bucket}/#{key}"
-      else
-        "https://#{bucket}.s3.amazonaws.com/#{key}"
+      cond do
+        endpoint_url ->
+          "#{endpoint_url}/#{bucket}/#{key}"
+
+        accelerate ->
+          "https://#{bucket}.s3-accelerate.amazonaws.com/#{key}"
+
+        true ->
+          "https://#{bucket}.s3.amazonaws.com/#{key}"
       end
     end)
     |> Keyword.update!(:url, &normalize_url(&1, options[:endpoint_url]))
     |> Keyword.put(:service, "s3")
-    |> Keyword.put_new(:datetime, DateTime.utc_now())
-    |> Keyword.drop([:bucket, :key, :endpoint_url])
+    |> Keyword.put(:datetime, DateTime.utc_now())
+    |> Keyword.drop([:bucket, :key, :endpoint_url, :accelerate])
     |> Req.Utils.aws_sigv4_url()
     |> URI.to_string()
   end
@@ -381,7 +389,7 @@ defmodule ReqS3 do
 
         url
 
-      [_ | _]  ->
+      [_ | _] ->
         # bucket has dots in it
         bucket = url.host
 

--- a/lib/req_s3.ex
+++ b/lib/req_s3.ex
@@ -249,7 +249,8 @@ defmodule ReqS3 do
         :expires_in,
         :bucket,
         :key,
-        :endpoint_url
+        :endpoint_url,
+        :s3_accelerate
       ]
     )
 
@@ -344,12 +345,18 @@ defmodule ReqS3 do
       end
 
     endpoint_url = options[:endpoint_url] || System.get_env("AWS_ENDPOINT_URL_S3")
+    s3_accelerate = options[:s3_accelerate]
 
     url =
-      if endpoint_url do
-        "#{endpoint_url}/#{bucket}"
-      else
-        "https://#{options[:bucket]}.s3.amazonaws.com"
+      cond do
+        endpoint_url ->
+          "#{endpoint_url}/#{bucket}"
+
+        s3_accelerate ->
+          "https://#{options[:bucket]}.s3-accelerate.amazonaws.com"
+
+        true ->
+          "https://#{options[:bucket]}.s3.amazonaws.com"
       end
 
     %{

--- a/lib/req_s3.ex
+++ b/lib/req_s3.ex
@@ -11,7 +11,7 @@ defmodule ReqS3 do
   def attach(request, options \\ []) do
     request
     |> Req.Request.register_options([:aws_endpoint_url_s3])
-    |> Req.Request.register_options([:s3_accelerate])
+    |> Req.Request.register_options([:accelerate])
     |> add_request_steps_before([s3_handle_url: &__MODULE__.handle_s3_url/1], :put_aws_sigv4)
     |> Req.merge(options)
     |> add_request_steps_before(
@@ -21,7 +21,7 @@ defmodule ReqS3 do
   end
 
   def use_acceleration(request) do
-    if request.options[:s3_accelerate] do
+    if request.options[:accelerate] do
       host =
         String.replace_suffix(
           request.url.host,
@@ -116,7 +116,7 @@ defmodule ReqS3 do
     * `:endpoint_url` - if set, the endpoint URL for S3-compatible services. If
       `AWS_ENDPOINT_URL_S3` system environment variable is set, it is considered first.
 
-    * `:s3_accelerate` - if set, use the S3 Accelerate endpoint.
+    * `:accelerate` - if set, use the S3 Accelerate endpoint.
 
   ## Examples
 
@@ -250,7 +250,7 @@ defmodule ReqS3 do
         :bucket,
         :key,
         :endpoint_url,
-        :s3_accelerate
+        :accelerate
       ]
     )
 
@@ -345,14 +345,14 @@ defmodule ReqS3 do
       end
 
     endpoint_url = options[:endpoint_url] || System.get_env("AWS_ENDPOINT_URL_S3")
-    s3_accelerate = options[:s3_accelerate]
+    accelerate = options[:accelerate]
 
     url =
       cond do
         endpoint_url ->
           "#{endpoint_url}/#{bucket}"
 
-        s3_accelerate ->
+        accelerate ->
           "https://#{options[:bucket]}.s3-accelerate.amazonaws.com"
 
         true ->

--- a/test/req_s3_test.exs
+++ b/test/req_s3_test.exs
@@ -215,6 +215,18 @@ defmodule ReqS3Test do
     end
   end
 
+  test "presing_url/1 with s3 transefer accelerator" do
+    assert "https://bucket.s3-accelerate.amazonaws.com/key.ext?X-Amz-Algorithm=AWS4-HMAC-SHA256&" <>
+             _ =
+             ReqS3.presign_url(
+               bucket: "bucket",
+               key: "key.ext",
+               s3_accelerate: true,
+               access_key_id: "",
+               secret_access_key: ""
+             )
+  end
+
   @tag :tmp_dir
   test "presign_form/1", %{tmp_dir: tmp_dir} do
     bucket = System.fetch_env!("BUCKET_NAME")

--- a/test/req_s3_test.exs
+++ b/test/req_s3_test.exs
@@ -221,7 +221,7 @@ defmodule ReqS3Test do
              ReqS3.presign_url(
                bucket: "bucket",
                key: "key.ext",
-               s3_accelerate: true,
+               accelerate: true,
                access_key_id: "",
                secret_access_key: ""
              )


### PR DESCRIPTION
Hi! As discussed in #16, this code adds support for `presign_url/1` to use [S3 Transfer Acceleration](https://aws.amazon.com/es/s3/transfer-acceleration/).

Example:
```elixir
options = [
	access_key_id: "key",
	secret_access_key: "secret",
	s3_accelerate: true
]

ReqS3.presign_url([bucket: "bucket", key: "key.ext"] ++ options)
# "https://bucket.s3-accelerate.amazonaws.com/key.ext?X-Amz-Algorithm=AWS4-HMAC-SHA256&..."
```