### PR TITLE
support bucket names with a period in it

### DIFF
--- a/lib/req_s3.ex
+++ b/lib/req_s3.ex
@@ -374,6 +374,29 @@ defmodule ReqS3 do
 
         url
 
+      [_ | _]  ->
+        # bucket has dots in it
+        bucket = url.host
+
+        url =
+          if endpoint_url do
+            endpoint_url = URI.new!(endpoint_url)
+
+            %{
+              url
+              | scheme: endpoint_url.scheme,
+                host: endpoint_url.host,
+                authority: nil,
+                port: endpoint_url.port,
+                path: "/#{bucket}#{url.path}"
+            }
+          else
+            host = "s3.amazonaws.com"
+            %{url | host: host, authority: nil, path: "/#{bucket}#{url.path}"}
+          end
+
+        url
+
       # leave e.g. s3.amazonaws.com as is
       _ ->
         url

--- a/test/req_s3_test.exs
+++ b/test/req_s3_test.exs
@@ -60,21 +60,14 @@ defmodule ReqS3Test do
   end
 
   @tag :integration
-  test "list versions" do
-    bucket = System.fetch_env!("BUCKET_NAME")
-
+  test "list objects with bucket with period in name" do
     req =
       Req.new()
       |> ReqS3.attach()
 
-    body = Req.get!(req, url: "s3://#{bucket}?versions").body
-
-    assert %{
-             "ListVersionsResult" => %{
-               "Name" => ^bucket,
-               "Version" => [%{"Key" => _, "VersionId" => _} | _]
-             }
-           } = body
+    %{status: 200} = Req.put!(req, url: "s3://wojtekmach.test")
+    %{status: 200} = Req.put!(req, url: "s3://wojtekmach.test/1", body: "1")
+    %{status: 200, body: "1"} = Req.get!(req, url: "s3://wojtekmach.test/1")
   end
 
   @tag :integration
@@ -103,6 +96,24 @@ defmodule ReqS3Test do
     else
       System.delete_env("AWS_ENDPOINT_URL_S3")
     end
+  end
+
+  @tag :integration
+  test "list versions" do
+    bucket = System.fetch_env!("BUCKET_NAME")
+
+    req =
+      Req.new()
+      |> ReqS3.attach()
+
+    body = Req.get!(req, url: "s3://#{bucket}?versions").body
+
+    assert %{
+             "ListVersionsResult" => %{
+               "Name" => ^bucket,
+               "Version" => [%{"Key" => _, "VersionId" => _} | _]
+             }
+           } = body
   end
 
   describe "aws_sigv4" do


### PR DESCRIPTION
Closes #18

Buckets with a period in it, i.e: test.bucket must be accessed via https://s3.amazonaws.com/test.bucket

This PR adds support for this. 

Discussed here https://github.com/wojtekmach/req_s3/issues/18